### PR TITLE
Feature/sphere segment voxel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -441,3 +441,7 @@ FodyWeavers.xsd
 /out
 /pyRadSim
 /pyRadSim.egg-info
+*.rf3
+spherical_data.csv
+test_dataset/
+.pytest_cache/

--- a/include/Geant4/G4RadiationFieldDetector.hpp
+++ b/include/Geant4/G4RadiationFieldDetector.hpp
@@ -61,6 +61,8 @@ namespace RadiationSimulation {
 				this->buffer.clear_layer<float>("hits", 0.f);
 				this->buffer.clear_layer<glm::vec3>("direction", glm::vec3(0.f));
 				this->buffer.clear_layer<float>("spectrum", 0.f, this->buffer.get_voxel_flat<RadFiled3D::HistogramVoxel>("spectrum", 0).get_bins());
+				if (this->buffer.has_layer("angular"))
+					this->buffer.clear_layer<float>("angular", 0.f, this->buffer.get_voxel_flat<RadFiled3D::SphericalVoxel>("angular", 0).get_total_segments());
 			}
 
 			inline float get_total_energy() const { return this->total_energy; }
@@ -136,6 +138,16 @@ namespace RadiationSimulation {
 
 					(&hist_voxel.get_data())[index] += 1.f;
 					this->spectra_variance[voxel_idx].add(hist_voxel);
+
+					if (this->buffer.has_layer("angular")) {
+						float r = glm::length(direction);
+						if (r > 0.f) {
+							float theta = std::acos(glm::clamp(direction.z / r, -1.f, 1.f));
+							float phi = std::atan2(direction.y, direction.x);
+							if (phi < 0.f) phi += 2.f * 3.14159265358979323846f;
+							this->buffer.get_voxel_flat<RadFiled3D::SphericalVoxel>("angular", voxel_idx).add_value(phi, theta, 1.f);
+						}
+					}
 				}
 			}
 
@@ -143,7 +155,7 @@ namespace RadiationSimulation {
 				return this->spectra_variance[this->buffer.get_voxel_idx(x, y, z)].get_relative_error();
 			}
 
-			ChannelBuffers(RadFiled3D::VoxelGridBuffer& buffer, float spectra_bin_width, size_t spectra_bins) 
+			ChannelBuffers(RadFiled3D::VoxelGridBuffer& buffer, float spectra_bin_width, size_t spectra_bins, size_t angular_phi_segments = 0, size_t angular_theta_segments = 0)
 				: buffer(buffer),
 				  half_field_dim(
 					  glm::vec3(
@@ -161,13 +173,17 @@ namespace RadiationSimulation {
 				buffer.add_layer<float>("hits", 0.f, "counts");
 				buffer.add_layer<glm::vec3>("direction", glm::vec3(0.f), "direction vector");
 				buffer.add_custom_layer<RadFiled3D::HistogramVoxel>("spectrum", RadFiled3D::HistogramVoxel(spectra_bins, spectra_bin_width, nullptr), 0.f, "eV");
+				if (angular_phi_segments > 0 && angular_theta_segments > 0)
+					buffer.add_custom_layer<RadFiled3D::SphericalVoxel>("angular", RadFiled3D::SphericalVoxel(angular_phi_segments, angular_theta_segments, nullptr), 0.f, "");
 			}
 
-			ChannelBuffers(const ChannelBuffers& other) 
+			ChannelBuffers(const ChannelBuffers& other)
 				: ChannelBuffers(
 					other.buffer,
 					other.buffer.get_voxel_flat<RadFiled3D::HistogramVoxel>("spectrum", 0).get_histogram_bin_width(),
-					other.buffer.get_voxel_flat<RadFiled3D::HistogramVoxel>("spectrum", 0).get_bins()
+					other.buffer.get_voxel_flat<RadFiled3D::HistogramVoxel>("spectrum", 0).get_bins(),
+					other.buffer.has_layer("angular") ? other.buffer.get_voxel_flat<RadFiled3D::SphericalVoxel>("angular", 0).get_phi_segments() : 0,
+					other.buffer.has_layer("angular") ? other.buffer.get_voxel_flat<RadFiled3D::SphericalVoxel>("angular", 0).get_theta_segments() : 0
 				) {}
 		};
 
@@ -206,7 +222,7 @@ namespace RadiationSimulation {
 		std::shared_ptr<RadFiled3D::GridTracer> tracer;
 		std::vector< std::function<void(size_t, const G4Step*)>> new_particle_callbacks;
 	public:
-		G4RadiationFieldDetector(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, size_t spectra_bins, double spectra_bin_width, float statistical_error_threshold = 0.1f, float statistical_error_enforcement_ratio = 0.9f);
+		G4RadiationFieldDetector(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, size_t spectra_bins, double spectra_bin_width, float statistical_error_threshold = 0.1f, float statistical_error_enforcement_ratio = 0.9f, size_t angular_phi_segments = 0, size_t angular_theta_segments = 0);
 		virtual ~G4RadiationFieldDetector() {
 			G4cout << "G4RadiationFieldDetector destroyed" << G4endl;
 		}

--- a/include/RadiationSimulation.hpp
+++ b/include/RadiationSimulation.hpp
@@ -86,7 +86,7 @@ namespace RadiationSimulation {
 		 * @param statistical_error_threshold Statistical error threshold that needs to be fullfilled by a certain amount of voxels for early stopping of the simulation.
 		 * @param statistical_error_enforcement_ratio Ratio of voxels that need to fullfill the statistical error threshold. The enforcement is done on the top x% of voxels sorted by their errors.
 		 */
-		static void set_radiation_field_resolution(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, float radiation_field_max_energy, float energy_resolution, float statistical_error_threshold, float statistical_error_enforcement_ratio);
+		static void set_radiation_field_resolution(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, float radiation_field_max_energy, float energy_resolution, float statistical_error_threshold, float statistical_error_enforcement_ratio, size_t angular_phi_segments = 0, size_t angular_theta_segments = 0);
 
 		/**
 		 * @brief Deinitializes the radiation simulator.

--- a/include/RadiationSimulationHandler.hpp
+++ b/include/RadiationSimulationHandler.hpp
@@ -31,6 +31,8 @@ namespace RadiationSimulation {
 				float threshold = 0.1f; ///< Statistical error threshold for the simulation.
 				float enforcement_ratio = 0.9f; ///< Statistical error enforcement over the top particles inside the ratio.
 			} statistical_error;
+			size_t angular_phi_segments = 0; ///< Number of phi segments for angular distribution per voxel. 0 = disabled.
+			size_t angular_theta_segments = 0; ///< Number of theta segments for angular distribution per voxel. 0 = disabled.
 		} radiation_field_resolution;
 	public:
 		/**
@@ -58,7 +60,7 @@ namespace RadiationSimulation {
 		 * @param statistical_error_threshold Statistical error threshold that needs to be fullfilled by a certain amount of voxels.
 		 * @param statistical_error_enforcement_ratio Ratio of voxels that need to fullfill the statistical error threshold. The enforcement is done on the top x% of voxels sorted by their errors.
 		 */
-		void set_radiation_field_resolution(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, float radiation_field_max_energy, float energy_resolution, float statistical_error_threshold, float statistical_error_enforcement_ratio);
+		void set_radiation_field_resolution(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, float radiation_field_max_energy, float energy_resolution, float statistical_error_threshold, float statistical_error_enforcement_ratio, size_t angular_phi_segments = 0, size_t angular_theta_segments = 0);
 
 		/**
 		 * @brief Add geometry to the simulation.

--- a/src/Geant4/G4RadiationFieldDetector.cpp
+++ b/src/Geant4/G4RadiationFieldDetector.cpp
@@ -127,13 +127,13 @@ void RadiationSimulation::G4RadiationFieldDetector::score_step_for(const G4Step*
 	}
 }
 
-RadiationSimulation::G4RadiationFieldDetector::G4RadiationFieldDetector(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, size_t spectra_bins, double spectra_bin_width, float statistical_error_threshold, float statistical_error_enforcement_ratio)
+RadiationSimulation::G4RadiationFieldDetector::G4RadiationFieldDetector(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, size_t spectra_bins, double spectra_bin_width, float statistical_error_threshold, float statistical_error_enforcement_ratio, size_t angular_phi_segments, size_t angular_theta_segments)
 	: RadiationFieldDetector(radiation_field_dimensions, radiation_field_voxel_dimensions, spectra_bins, spectra_bin_width),
 	  statistical_error_threshold(statistical_error_threshold),
 	  statistical_error_enforcement_ratio(statistical_error_enforcement_ratio),
 	  buffers(
-	      ChannelBuffers(*static_cast<RadFiled3D::VoxelGridBuffer*>(field->add_channel("scatter_field").get()), static_cast<float>(spectra_bin_width), spectra_bins),
-		  ChannelBuffers(*static_cast<RadFiled3D::VoxelGridBuffer*>(field->add_channel("xray_beam").get()), static_cast<float>(spectra_bin_width), spectra_bins)
+	      ChannelBuffers(*static_cast<RadFiled3D::VoxelGridBuffer*>(field->add_channel("scatter_field").get()), static_cast<float>(spectra_bin_width), spectra_bins, angular_phi_segments, angular_theta_segments),
+		  ChannelBuffers(*static_cast<RadFiled3D::VoxelGridBuffer*>(field->add_channel("xray_beam").get()), static_cast<float>(spectra_bin_width), spectra_bins, angular_phi_segments, angular_theta_segments)
 	  ),
 	  G4UserSteppingAction()
 {

--- a/src/RadiationSimulation.cpp
+++ b/src/RadiationSimulation.cpp
@@ -68,9 +68,9 @@ void RadiationSimulation::RadiationSimulator::add_radiation_source(std::shared_p
 	World::Get()->radiation_source = source;
 }
 
-void RadiationSimulation::RadiationSimulator::set_radiation_field_resolution(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, float radiation_field_max_energy, float energy_resolution, float statistical_error_threshold, float statistical_error_enforcement_ratio)
+void RadiationSimulation::RadiationSimulator::set_radiation_field_resolution(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, float radiation_field_max_energy, float energy_resolution, float statistical_error_threshold, float statistical_error_enforcement_ratio, size_t angular_phi_segments, size_t angular_theta_segments)
 {
-	RadiationSimulator::handler->set_radiation_field_resolution(radiation_field_dimensions, radiation_field_voxel_dimensions, radiation_field_max_energy, energy_resolution, statistical_error_threshold, statistical_error_enforcement_ratio);
+	RadiationSimulator::handler->set_radiation_field_resolution(radiation_field_dimensions, radiation_field_voxel_dimensions, radiation_field_max_energy, energy_resolution, statistical_error_threshold, statistical_error_enforcement_ratio, angular_phi_segments, angular_theta_segments);
 }
 
 void RadiationSimulation::RadiationSimulator::set_world_info(std::unique_ptr<RadiationSimulation::WorldInfo> info)

--- a/src/RadiationSimulationHandler.cpp
+++ b/src/RadiationSimulationHandler.cpp
@@ -106,7 +106,10 @@ void RadiationSimulation::G4RadiationSimulationHandler::finalize()
 			this->radiation_field_resolution.radiation_field_voxel_dimensions,
 			static_cast<size_t>(this->radiation_field_resolution.radiation_field_max_energy / this->radiation_field_resolution.energy_resolution),
 			static_cast<double>(this->radiation_field_resolution.energy_resolution),
-			this->radiation_field_resolution.statistical_error.threshold
+			this->radiation_field_resolution.statistical_error.threshold,
+			this->radiation_field_resolution.statistical_error.enforcement_ratio,
+			this->radiation_field_resolution.angular_phi_segments,
+			this->radiation_field_resolution.angular_theta_segments
 		);
 		rad_det->register_on_new_particle([=](size_t evt_count, const G4Step* step) {
 			for (auto& cb : this->callbacks) {
@@ -150,7 +153,9 @@ void RadiationSimulation::G4RadiationSimulationHandler::display_gui()
 {
 #ifdef WITH_GEANT4_UIVIS
 	G4cout << "Displaying GUI..." << G4endl;
-	auto ui = std::unique_ptr<G4UIExecutive>(new G4UIExecutive(0, NULL)); // Use unique_ptr
+	int dummy_argc = 1;
+	char* dummy_argv[] = { (char*)"RadField3D" };
+	auto ui = std::unique_ptr<G4UIExecutive>(new G4UIExecutive(dummy_argc, dummy_argv));
 	this->has_ui = true;
 	this->G4VisManager = std::make_unique<G4VisExecutive>();
 	this->G4VisManager->Initialize();
@@ -236,7 +241,7 @@ void RadiationSimulation::G4RadiationSimulationHandler::add_callback_every_n_par
 	callbacks.push_back({ n_particles, callback });
 }
 
-void RadiationSimulation::RadiationSimulationHandler::set_radiation_field_resolution(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, float radiation_field_max_energy, float energy_resolution, float statistical_error_threshold, float statistical_error_enforcement_ratio)
+void RadiationSimulation::RadiationSimulationHandler::set_radiation_field_resolution(const glm::vec3& radiation_field_dimensions, const glm::vec3& radiation_field_voxel_dimensions, float radiation_field_max_energy, float energy_resolution, float statistical_error_threshold, float statistical_error_enforcement_ratio, size_t angular_phi_segments, size_t angular_theta_segments)
 {
 	this->radiation_field_resolution.radiation_field_dimensions = radiation_field_dimensions;
 	this->radiation_field_resolution.radiation_field_voxel_dimensions = radiation_field_voxel_dimensions;
@@ -244,4 +249,6 @@ void RadiationSimulation::RadiationSimulationHandler::set_radiation_field_resolu
 	this->radiation_field_resolution.energy_resolution = energy_resolution;
 	this->radiation_field_resolution.statistical_error.threshold = statistical_error_threshold;
 	this->radiation_field_resolution.statistical_error.enforcement_ratio = statistical_error_enforcement_ratio;
+	this->radiation_field_resolution.angular_phi_segments = angular_phi_segments;
+	this->radiation_field_resolution.angular_theta_segments = angular_theta_segments;
 }

--- a/targets/radfield3d/RadField3D.cpp
+++ b/targets/radfield3d/RadField3D.cpp
@@ -108,6 +108,8 @@ int main(int argc, char* argv[]) {
 	std::string source_shape = "cone";
 	std::string world_material = "Air";
 	int cpu_count = -1;
+	size_t angular_phi_segments = 0;
+	size_t angular_theta_segments = 0;
 	RadFiled3D::GridTracerAlgorithm tracing_algorithm = RadFiled3D::GridTracerAlgorithm::SAMPLING;
 
 
@@ -207,6 +209,21 @@ int main(int argc, char* argv[]) {
 		}
 		if (arg == "--cpu-count") {
 			cpu_count = std::stoi(value);
+			continue;
+		}
+		if (arg == "--angular-resolution") {
+			try {
+				std::stringstream ssin(value);
+				size_t phi, theta;
+				ssin >> phi;
+				ssin >> theta;
+				angular_phi_segments = phi;
+				angular_theta_segments = theta;
+			}
+			catch (std::exception& e) {
+				G4cerr << "Invalid argument for angular resolution: " << value << G4endl;
+				throw e;
+			}
 			continue;
 		}
 		if (arg == "--source-opening-angle") {
@@ -442,7 +459,7 @@ int main(int argc, char* argv[]) {
 	RadiationSimulator::add_radiation_source(source);
 	RadiationSimulator::add_geometry(meshes);
 
-	RadiationSimulator::set_radiation_field_resolution(world_dim, glm::vec3(voxel_dim), max_energy * eV, energy_resolution * eV, statistical_error_threshold, statistical_error_enforcement_ratio);
+	RadiationSimulator::set_radiation_field_resolution(world_dim, glm::vec3(voxel_dim), max_energy * eV, energy_resolution * eV, statistical_error_threshold, statistical_error_enforcement_ratio, angular_phi_segments, angular_theta_segments);
 
 	G4cout << "Using world dimensions: " << world_dim.x << "m x " << world_dim.y << "m x " << world_dim.z << "m" << G4endl;
 	G4cout << "Using world material: " << world_material << G4endl;


### PR DESCRIPTION
## Summary
- Integrates SphericalVoxel angular scoring into the Geant4 simulation pipeline
- Adds `--angular-resolution "phi theta"` CLI parameter to enable per-voxel directional radiation tracking
- Fixes GUI crash on Windows caused by null argc/argv in G4UIExecutive

**Note:** Depends on [RadFiled3D PR #X](https://github.com/Centrasis/RadFiled3D/pull/4) — the submodule PR must be merged first.

## Changes

**Angular scoring in simulation (`G4RadiationFieldDetector.hpp`):**
- `score()`: Converts photon direction to spherical coordinates (phi, theta) and scores into SphericalVoxel
- `reset()`: Clears angular layer when present
- `ChannelBuffers`: Accepts `angular_phi_segments` and `angular_theta_segments` parameters
- Angular layer is optional — when segments are 0, no layer is created (backward compatible)

**Parameter pipeline (`RadiationSimulation.hpp`, `RadiationSimulationHandler.hpp/cpp`):**
- `set_radiation_field_resolution()` extended with `angular_phi_segments` and `angular_theta_segments` (default 0 = disabled)
- Parameters stored in `radiation_field_resolution` struct and passed through to `G4RadiationFieldDetector`

**CLI (`RadField3D.cpp`):**
- New `--angular-resolution "phi theta"` argument (e.g. `--angular-resolution "12 6"` for 72 directional bins per voxel)
- Parsed and forwarded through the full parameter chain

**GUI fix (`RadiationSimulationHandler.cpp`):**
- Fixed `G4UIExecutive(0, NULL)` → `G4UIExecutive(dummy_argc, dummy_argv)` to prevent access violation on Windows

## Usage
```bash
./RadField3D --geom scene.obj --spectrum spectrum.csv --out output.rf3 \
    --angular-resolution "12 6" \
    --particles 10000 --voxel-dim 0.1 --world-dim "1 1 1"